### PR TITLE
Update vite.config.ts to relative paths

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -12,6 +12,7 @@ export default defineConfig(async () => ({
     clearScreen: false,
     // 2. tauri expects a fixed port, fail if that port is not available
     server: {
+        base: './',
         port: 1420,
         strictPort: true,
         host: host || false,


### PR DESCRIPTION
This is useful for deploying directly to itch.io which requires relative paths.

"" or "./" instructs vite to build using relative paths. I don't know all of the side effects of this, but the dev and build using tauri still works with this addition to the config.


Everything else works except for some reason the html page is still generated with "/" instead of "./" but, if I go to the index.html page and add in the "." directly into the relevant places I can push to itch.io using their tool butler with no issues.

https://itch.io/docs/butler/

If some one knows how to resolve the final step automatically that would be amazing, but if not, I would still be happy to write out instructions in the readme for people to follow.

It would be the best if I can use this same repo to build our demo executable for steam and the web version needed to publish to itch.io.

Here is the generated html file even with base: "./"
```html
<!doctype html>
<html lang="en">
<head>
    <meta charset="UTF-8" />
    <link rel="icon" type="image/png" href="/favicon.png" />
    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
    <link rel="stylesheet" href="/style.css">
    <title>Portal Snake</title>
  <script type="module" crossorigin src="/assets/index-5RjaTzyh.js"></script>
</head>

<body>
    <div id="app">
        <div id="game-container"></div>
    </div>

</body>
</html>
```

And the manual edits I make to push to itch.io.
```html
<!doctype html>
<html lang="en">
<head>
    <meta charset="UTF-8" />
    <link rel="icon" type="image/png" href="./favicon.png" />
    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
    <link rel="stylesheet" href="./style.css">
    <title>Portal Snake</title>
  <script type="module" crossorigin src="./assets/index-5RjaTzyh.js"></script>
</head>

<body>
    <div id="app">
        <div id="game-container"></div>
    </div>

</body>
</html>
```